### PR TITLE
Rework label names and drop annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,23 +35,23 @@ Usage of ./kube-policy-semaphore:
 ## Operator
 
   Kube-policy-semaphore will watch the target cluster pods which are labelled
-with: `semaphore.uw.system/name`. For these pods it will extract a name from
+with: `semaphore.uw.systems/name`. For these pods it will extract a name from
 the label and will use it along with the namespace of the pod and the cluster it
 resides to create a GlobalNetworkSet resource (or amend an existing one) on the
 local cluster. Using namespace and cluster name will help avoiding conflicts
 with workloads from different locations that want to use the same value for
-`semaphore.uw.system/name`.
+`semaphore.uw.systems/name`.
 
-  For example annotating a pod with `semaphore.uw.system/name=my-app` under a
+  For example annotating a pod with `semaphore.uw.systems/name=my-app` under a
 namespace called `my-ns` in a cluster called `my-cluster` will tell the operator
 to add the pod's ip to a network set named my-cluster-my-ns-my-app. In order to
 make it easier to select that set in network policies, the following labels will
 be added:
 ```
 managed-by=calico-global-network-sync-operator
-semaphore.uw.system/name=my-app
-semaphore.uw.system/namespace=my-ns
-semaphore.uw.system/cluster=my-cluster
+semaphore.uw.systems/name=my-app
+semaphore.uw.systems/namespace=my-ns
+semaphore.uw.systems/cluster=my-cluster
 ```
 
   Thus, one can use the above labels to target the created GlocalNetworkSet
@@ -65,9 +65,9 @@ Example of a generated global network set from the operator:
 Name:         my-cluster-my-ns-my-app
 Namespace:
 Labels:       managed-by=calico-global-network-sync-operator
-              semaphore.uw.system/name=my-app
-              semaphore.uw.system/namespace=my-ns
-              semaphore.uw.system/cluster=my-cluster
+              semaphore.uw.systems/name=my-app
+              semaphore.uw.systems/namespace=my-ns
+              semaphore.uw.systems/cluster=my-cluster
 API Version:  crd.projectcalico.org/v1
 Kind:         GlobalNetworkSet
 Spec:
@@ -93,7 +93,7 @@ spec:
   - action: Allow
     protocol: TCP
     source:
-      selector: semaphore.uw.system/name == 'my-app' && semaphore.uw.system/namespace == 'my-ns' && semaphore.uw.system/cluster == 'my-cluster'
+      selector: semaphore.uw.systems/name == 'my-app' && semaphore.uw.systems/namespace == 'my-ns' && semaphore.uw.systems/cluster == 'my-cluster'
       namespaceSelector: global()
 ```
 

--- a/main.go
+++ b/main.go
@@ -20,9 +20,9 @@ import (
 const (
 	labelManagedBy       = "managed-by"
 	keyManagedBy         = "calico-global-network-sync-operator"
-	labelNetSetCluster   = "semaphore.uw.system/cluster"
-	labelNetSetName      = "semaphore.uw.system/name"
-	labelNetSetNamespace = "semaphore.uw.system/namespace"
+	labelNetSetCluster   = "semaphore.uw.systems/cluster"
+	labelNetSetName      = "semaphore.uw.systems/name"
+	labelNetSetNamespace = "semaphore.uw.systems/namespace"
 )
 
 var (

--- a/main.go
+++ b/main.go
@@ -18,25 +18,23 @@ import (
 )
 
 const (
-	labelManagedBy         = "managed-by"
-	keyManagedBy           = "calico-global-network-sync-operator"
-	labelRemoteClusterName = "remote-cluster-name"
-	labelNetSetName        = "name"
-	labelNetSetNamespace   = "namespace"
+	labelManagedBy       = "managed-by"
+	keyManagedBy         = "calico-global-network-sync-operator"
+	labelNetSetCluster   = "semaphore.uw.system/cluster"
+	labelNetSetName      = "semaphore.uw.system/name"
+	labelNetSetNamespace = "semaphore.uw.system/namespace"
 )
 
 var (
-	flagKubeConfigPath           = flag.String("local-kube-config", getEnv("KPS_LOCAL_KUBE_CONFIG", ""), "Path of the local kube cluster config file, if not provided the app will try to get in cluster config")
-	flagTargetKubeConfigPath     = flag.String("target-kube-config", getEnv("KPS_TARGET_KUBE_CONFIG", ""), "(Required) Path of the target cluster kube config file to add wg peers from")
-	flagLabelSelector            = flag.String("label-selector", getEnv("KPS_LABEL_SELECTOR", "uw.systems/networksets=true"), "Label of pods to watch and create/update network sets.")
-	flagNetworkSetNameAnnotation = flag.String("networkset-name-annotation", getEnv("KPS_NETSET_NAME_ANNOTATION", "uw.systems/networkset-name"), "Pod annotation with the name of the set the pod belong to")
-	flagLogLevel                 = flag.String("log-level", getEnv("KPS_LOG_LEVEL", "info"), "Log level")
-	flagRemoteAPIURL             = flag.String("remote-api-url", getEnv("KPS_REMOTE_API_URL", ""), "Remote Kubernetes API server URL")
-	flagRemoteCAURL              = flag.String("remote-ca-url", getEnv("KPS_REMOTE_CA_URL", ""), "Remote Kubernetes CA certificate URL")
-	flagRemoteSATokenPath        = flag.String("remote-sa-token-path", getEnv("KPS_REMOTE_SERVICE_ACCOUNT_TOKEN_PATH", ""), "Remote Kubernetes cluster token path")
-	flagFullStoreResyncPeriod    = flag.Duration("full-store-resync-period", 60*time.Minute, "Frequency to perform a full network set store resync from cache to calico GlocalNetworkPolicies")
-	flagPodResyncPeriod          = flag.Duration("pod-resync-period", 60*time.Minute, "Pod watcher cache resync period")
-	flagTargetCluster            = flag.String("target-cluster-name", getEnv("KPS_TARGET_CLUSTER_NAME", ""), "(required) The name of the cluster from which pods are synced as networksets.It will also be used as a prefix used when creating network sets.")
+	flagKubeConfigPath        = flag.String("local-kube-config", getEnv("KPS_LOCAL_KUBE_CONFIG", ""), "Path of the local kube cluster config file, if not provided the app will try to get in cluster config")
+	flagTargetKubeConfigPath  = flag.String("target-kube-config", getEnv("KPS_TARGET_KUBE_CONFIG", ""), "(Required) Path of the target cluster kube config file to watch pods")
+	flagLogLevel              = flag.String("log-level", getEnv("KPS_LOG_LEVEL", "info"), "Log level")
+	flagRemoteAPIURL          = flag.String("remote-api-url", getEnv("KPS_REMOTE_API_URL", ""), "Remote Kubernetes API server URL")
+	flagRemoteCAURL           = flag.String("remote-ca-url", getEnv("KPS_REMOTE_CA_URL", ""), "Remote Kubernetes CA certificate URL")
+	flagRemoteSATokenPath     = flag.String("remote-sa-token-path", getEnv("KPS_REMOTE_SERVICE_ACCOUNT_TOKEN_PATH", ""), "Remote Kubernetes cluster token path")
+	flagFullStoreResyncPeriod = flag.Duration("full-store-resync-period", 60*time.Minute, "Frequency to perform a full network set store resync from cache to calico GlocalNetworkPolicies")
+	flagPodResyncPeriod       = flag.Duration("pod-resync-period", 60*time.Minute, "Pod watcher cache resync period")
+	flagTargetCluster         = flag.String("target-cluster-name", getEnv("KPS_TARGET_CLUSTER_NAME", ""), "(required) The name of the cluster from which pods are synced as networksets. It will also be used as a prefix used when creating network sets.")
 
 	saToken  = os.Getenv("KPS_REMOTE_SERVICE_ACCOUNT_TOKEN")
 	bearerRe = regexp.MustCompile(`[A-Z|a-z0-9\-\._~\+\/]+=*`)
@@ -107,8 +105,6 @@ func main() {
 		homeCalicoClient,
 		remoteClient,
 		*flagTargetCluster,
-		*flagLabelSelector,
-		*flagNetworkSetNameAnnotation,
 		*flagFullStoreResyncPeriod,
 		*flagPodResyncPeriod,
 	)

--- a/networksets.go
+++ b/networksets.go
@@ -42,10 +42,10 @@ func newNetworkSetStore(cluster string, client calicoClient.Interface) NetworkSe
 
 func (nss *NetworkSetStore) addNetworkSet(id, name, namespace, net string) *NetworkSet {
 	labels := map[string]string{
-		labelManagedBy:         keyManagedBy,
-		labelRemoteClusterName: nss.cluster,
-		labelNetSetName:        name,
-		labelNetSetNamespace:   namespace,
+		labelManagedBy:       keyManagedBy,
+		labelNetSetCluster:   nss.cluster,
+		labelNetSetName:      name,
+		labelNetSetNamespace: namespace,
 	}
 	ns := &NetworkSet{
 		labels: labels,
@@ -125,8 +125,8 @@ func (nss *NetworkSetStore) RunSyncLoop() {
 		case <-nss.fullSyncQueue:
 			log.Logger.Debug("staring a new full sync loop")
 			currentNetSets, err := calico.GlobalNetworkSetList(nss.client, map[string]string{
-				labelManagedBy:         keyManagedBy,
-				labelRemoteClusterName: nss.cluster,
+				labelManagedBy:     keyManagedBy,
+				labelNetSetCluster: nss.cluster,
 			})
 			if err != nil {
 				log.Logger.Error("failed get the list of existing network sets, potential stale set left behind!", "cluster", nss.cluster)

--- a/networksets_test.go
+++ b/networksets_test.go
@@ -21,10 +21,10 @@ func TestNetworkSets(t *testing.T) {
 	assert.Equal(t, 1, len(netsSetStore.store))
 	id := makeNetworkSetID("name", "namespace", "test")
 	expectedLables := map[string]string{
-		labelManagedBy:         keyManagedBy,
-		labelRemoteClusterName: "test",
-		labelNetSetName:        "name",
-		labelNetSetNamespace:   "namespace",
+		labelManagedBy:       keyManagedBy,
+		labelNetSetCluster:   "test",
+		labelNetSetName:      "name",
+		labelNetSetNamespace: "namespace",
 	}
 	assert.Equal(t, 1, len(netsSetStore.store[id].nets))
 	assert.Equal(t, "10.0.0.0/24", netsSetStore.store[id].nets[0])
@@ -54,10 +54,10 @@ func TestNetworkSets(t *testing.T) {
 	assert.Equal(t, expectedLables, netsSetStore.store[id].labels)
 	id2 := makeNetworkSetID("name2", "namespace2", "test")
 	expectedLables2 := map[string]string{
-		labelManagedBy:         keyManagedBy,
-		labelRemoteClusterName: "test",
-		labelNetSetName:        "name2",
-		labelNetSetNamespace:   "namespace2",
+		labelManagedBy:       keyManagedBy,
+		labelNetSetCluster:   "test",
+		labelNetSetName:      "name2",
+		labelNetSetNamespace: "namespace2",
 	}
 	assert.Equal(t, 1, len(netsSetStore.store[id2].nets))
 	assert.Equal(t, "10.0.0.1/24", netsSetStore.store[id2].nets[0])

--- a/runner.go
+++ b/runner.go
@@ -101,7 +101,7 @@ func (r *Runner) PodEventHandler(eventType watch.EventType, old *v1.Pod, new *v1
 func (r *Runner) onPodAdd(pod *v1.Pod) {
 	name, ok := pod.Labels[labelNetSetName]
 	if !ok {
-		log.Logger.Error("Could not findlabel for pod", "label", labelNetSetName, "pod", pod.Name)
+		log.Logger.Error("Could not find label for pod", "label", labelNetSetName, "pod", pod.Name)
 		return
 	}
 	if pod.Status.PodIP != "" {


### PR DESCRIPTION
The watcher now will look for pods labelled with `semaphore.uw.system/name` and
extract the name value from there. Then the created GlobalNetworkSets will have
the following labels available:
- semaphore.uw.system/name: the name grabbed from the remote pod label
- semaphore.uw.system/namespace: the remote pods namespace
- semaphore.uw.system/cluster: the cluster name as passed via the related flag
  or env var.
The label keys are not configurable any more.